### PR TITLE
Fix rails 3 incompatibility regarding mass assignment protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Unreleased
+
+* Fixed mass assignment protection errors under Rails 3
+
 ## 1.0.1 (2019-01-29)
 
 * Fixed reliance on `ActionController::Parameters`. Now the strong parameter

--- a/lib/rails_ops/context.rb
+++ b/lib/rails_ops/context.rb
@@ -7,6 +7,16 @@ module RailsOps
     attribute :called_via_hook
     attribute :url_options
 
+    # For compatibility with rails < 4
+    if defined?(attr_accessible)
+      attr_accessible :user
+      attr_accessible :ability
+      attr_accessible :op_chain
+      attr_accessible :session
+      attr_accessible :called_via_hook
+      attr_accessible :url_options
+    end
+
     # Returns a copy of the context with the given operation added to the
     # contexts operation chain.
     def spawn(op)


### PR DESCRIPTION
The RailsOps::Context#spawn method uses mass assignment. This is no
problem when relying on strong parameters, as introduced in Rails 4. For
Rails 3 projects however, this is a problem. To circumvent any errors
that spring up during normal trigger handling, allow mass assignment for
all attributes of RailsOps::Context.