### PR TITLE
Add a `:prepend_action` parameter to the policy function

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,21 @@ class MyOp
 end
 ```
 
+The order inside the same policy chain depends on the time when a block was added.
+You can prepend an action to a policy chain by setting `:prepend_action` to `true`:
+
+```ruby
+class MyOp
+  policy :on_init, prepend_action: true do
+    puts 'This is run first the operation has been instantiated.'
+  end
+```
+
+In this case the model is not yet set. That will happen later in the `:on_init` chain.
+It is also important to note, that this block is
+not guaranteed to be run first in the chain, if multiple blocks have set `:prepend_action` to true.
+
+
 Calling sub-operations
 ----------------------
 

--- a/lib/rails_ops/mixins/policies.rb
+++ b/lib/rails_ops/mixins/policies.rb
@@ -21,13 +21,17 @@ module RailsOps::Mixins::Policies
   module ClassMethods
     # Register a new policy block that will be executed in the given `chain`.
     # The policy block will be executed in the operation's instance context.
-    def policy(chain = :before_perform, &block)
+    def policy(chain = :before_perform, prepend_action: false, &block)
       unless POLICY_CHAIN_KEYS.include?(chain)
         fail "Unknown policy chain #{chain.inspect}, available are #{POLICY_CHAIN_KEYS.inspect}."
       end
 
       self._policy_chains = _policy_chains.dup
-      _policy_chains[chain] += [block]
+      if prepend_action
+        _policy_chains[chain] = [block] + _policy_chains[chain]
+      else
+        _policy_chains[chain] += [block]
+      end
     end
 
     # Returns all registered validation blocks for this operation class.

--- a/lib/rails_ops/operation/model.rb
+++ b/lib/rails_ops/operation/model.rb
@@ -110,10 +110,7 @@ class RailsOps::Operation::Model < RailsOps::Operation
   def assign_attributes(attributes = nil, model: nil, without_protection: false, without_nested_models: true)
     model ||= self.model
 
-    unless attributes
-      # Extract attributes from params hash
-      attributes = extract_attributes_from_params(model)
-    end
+    attributes ||= extract_attributes_from_params(model)
 
     if without_nested_models
       # Remove parameters that will be passed to nested model operations


### PR DESCRIPTION
It is now possible to add a policy in front of the policy chain
instead of the end. It is however not guaranteed to be the first
policy to be run since multiple policies can be prepended to the chain.
A prepended policy can't access the operation model, since it is not set
yet.