### PR TITLE
Properly invoke `defined?` to check for defined objects before trying to reference them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 1.0.9 (2019-05-29)
+
+* Changes to development setup
+
 ## 1.0.8 (2019-05-29)
 
 * Fix #14 Policy chain `after_perform` is never called.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Unreleased
+
+* Fix `defined?` calls in controller mixin so that the mixin can be used without
+  defining `current_user` or `current_ability`.
+
 ## 1.0.9 (2019-05-29)
 
 * Changes to development setup

--- a/lib/rails_ops/controller_mixin.rb
+++ b/lib/rails_ops/controller_mixin.rb
@@ -96,8 +96,8 @@ module RailsOps
     def op_context
       @op_context ||= begin
         context = RailsOps::Context.new
-        context.user = current_user if defined?(:current_user)
-        context.ability = current_ability if defined?(:current_ability)
+        context.user = current_user if defined?(current_user)
+        context.ability = current_ability if defined?(current_ability)
         context.session = session
         context.url_options = url_options
         context.view = view_context


### PR DESCRIPTION
The problem is that symbols always are defined, so the conditionals would evaluate to true. This is a problem with projects that do not use an authorization backend that provides the object `current_ability`, and likewise for user management that does not provide `current_user` to the controller.

This pull request also adds a missing entry to the change log (version 1.0.9).