### PR TITLE
Set nested param name to model name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 1.0.13 (2019-08-27)
+
+* Set the name of nested params to the modelname, not to the fieldname.
+  This is a follow up from 1.0.11.
+
 ## 1.0.12 (2019-08-20)
 
 * {RailsOps::Context#spawn} now dynamically inferrs current class name in order

--- a/lib/rails_ops/mixins/model/nesting.rb
+++ b/lib/rails_ops/mixins/model/nesting.rb
@@ -91,15 +91,17 @@ module RailsOps::Mixins::Model::Nesting
 
   def nested_model_op(attribute)
     fail 'Nested model operations have not been built yet.' unless @nested_model_ops
+
     return @nested_model_ops[attribute]
   end
 
   def build_nested_model_ops(action)
     # Validate action
-    fail 'Unsupported action.' unless [:create, :update].include?(action)
+    fail 'Unsupported action.' unless %i(create update).include?(action)
 
     # Make sure that this method can only be run once per operation
     fail 'Nested model operations can only be built once.' if @nested_model_ops
+
     @nested_model_ops = {}
 
     self.class._nested_model_ops.each do |attribute, config|
@@ -115,9 +117,11 @@ module RailsOps::Mixins::Model::Nesting
       end
 
       # Wrap parameters for nested model operation
+      model_class = config[:klass].name.deconstantize.demodulize.underscore.to_sym
+
       if action == :create
         wrapped_params = {
-          config[:attribute_name] => op_params
+          model_class => op_params
         }
       elsif action == :update
         if config[:lookup_via_id_on_update]
@@ -129,7 +133,7 @@ module RailsOps::Mixins::Model::Nesting
 
         wrapped_params = {
           :id => id,
-          config[:attribute_name] => op_params
+          model_class => op_params
         }
       else
         fail "Unsupported action #{action}."


### PR DESCRIPTION
Since version 1.0.11 allows nesting on a field with an explizit
class_name, the nested param name should not be set from the attribute
name anymore.