### PR TITLE
Fix eager loading decrepation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## UNRELEASED
+* Include the ControllerMixin after `ActionController::Base` has been loaded, as
+  directly calling `ActionController::Base.send :include, RailsOps::ControllerMixin`
+  in the railtie causes the `ActionController::Base` to be loaded during Initialization,
+  which is undesirable and will be an error in future Rails versions.
+
 ## 1.1.1 (2020-03-02)
 
 * Do not require default (CanCanCan) authorization backend anymore so that the

--- a/lib/rails_ops/railtie.rb
+++ b/lib/rails_ops/railtie.rb
@@ -18,7 +18,9 @@ module RailsOps
       # ---------------------------------------------------------------
       # Include controller mixin
       # ---------------------------------------------------------------
-      ActionController::Base.send :include, RailsOps::ControllerMixin
+      ActiveSupport.on_load :action_controller_base do
+        include RailsOps::ControllerMixin
+      end
     end
   end
 end


### PR DESCRIPTION
This commit changes the inclusion of the ControllerMixin to be loaded after ActionController::Base is loaded.