### PR TITLE
Add operation and controller generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /vendor/bundle
 /test/dummy/tmp/
 /test/dummy/log/
+/test/tmp/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'tmp/**/*'
     - 'log/**/*'
     - '*.gemspec'
+    - 'test/tmp/**/*'
 
   DisplayCopNames: true
 

--- a/README.md
+++ b/README.md
@@ -1488,6 +1488,55 @@ sub-operations, see section *Calling sub-operations* for more information.
 Operation Inheritance
 ---------------------
 
+Generators
+----------
+
+RailsOps features a generator to easily create a structure for common CRUD-style
+constructs. The generator creates the CRUD operations, some empty view files, a
+controller and adds an entry in the routing file.
+
+This is e.g. useful when adding a new model to an application, as the basic structure
+is usually rather similar.
+
+### Usage
+
+Run the generator using the `operation` generator, specifying the name of the
+operation class:
+
+```ruby
+rails g operation User
+```
+
+This will generate the following operations:
+
+* `app/operations/user/load.rb`
+* `app/operations/user/create.rb`
+* `app/operations/user/update.rb`
+* `app/operations/user/destroy.rb`
+
+as well as the controller `app/controllers/users_controller.rb` and the following
+empty view files:
+
+* `app/views/users/index.html.haml`
+* `app/views/users/show.html.haml`
+* `app/views/users/new.html.haml`
+* `app/views/users/edit.html.haml`
+
+It will also add the entry `resources :users` to the `config/routes.rb` file.
+
+If you want to skip the controller, the views or the routes, you can do so using the
+flags:
+
+* `--skip-controller`
+* `--skip-routes`
+* `--skip-views`
+
+Or if you want to skip them all: `--only-operations`.
+
+Of course, at this point, the operations will need some adaptions, especially the
+[parameter schemas](#validating-params), and the controllers need the logic for the
+success and failure cases, as this depends on your application.
+
 Caveats
 -------
 

--- a/lib/generators/operation/USAGE
+++ b/lib/generators/operation/USAGE
@@ -1,0 +1,21 @@
+Description:
+    Generates CRUD operations, along with a controller, views and an entry in the route file
+
+Example:
+    bin/rails generate operation User
+
+    This will create:
+        app/operations/user/load.rb
+        app/operations/user/create.rb
+        app/operations/user/update.rb
+        app/operations/user/destroy.rb
+
+        app/controllers/users_controller.rb
+
+        app/views/users/index.html.haml
+        app/views/users/show.html.haml
+        app/views/users/new.html.haml
+        app/views/users/edit.html.haml
+
+    And add a routing entry:
+        resources :users

--- a/lib/generators/operation/operation_generator.rb
+++ b/lib/generators/operation/operation_generator.rb
@@ -1,0 +1,46 @@
+class OperationGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+
+  class_option :skip_controller, type: :boolean, desc: "Don't add a controller."
+  class_option :skip_views, type: :boolean, desc: "Don't add the views."
+  class_option :skip_routes, type: :boolean, desc: "Don't add routes to config/routes.rb."
+  class_option :only_operations, type: :boolean, desc: 'Only add the operations. This is equal to specifying --skip-controller --skip-routes --skip-views'
+
+  def add_operations
+    @class_name = name.classify
+    @underscored_name = name.underscore
+    @underscored_pluralized_name = name.underscore.pluralize
+
+    operations_path = "app/operations/#{@underscored_name}"
+
+    template 'load.erb', "#{operations_path}/load.rb"
+    template 'create.erb', "#{operations_path}/create.rb"
+    template 'update.erb', "#{operations_path}/update.rb"
+    template 'destroy.erb', "#{operations_path}/destroy.rb"
+  end
+
+  def add_controller
+    return if options[:skip_controller] || options[:only_operations]
+
+    controller_file_path = "app/controllers/#{@underscored_pluralized_name}_controller.rb"
+    @controller_name = "#{@class_name.pluralize}Controller"
+
+    template 'controller.erb', controller_file_path
+  end
+
+  def add_views
+    return if options[:skip_views] || options[:only_operations]
+
+    views_folder = "app/views/#{@underscored_pluralized_name}"
+
+    %w(index show new edit).each do |view|
+      template 'view.erb', "#{views_folder}/#{view}.html.haml"
+    end
+  end
+
+  def add_routes
+    return if options[:skip_routes] || options[:only_operations]
+
+    route "resources :#{@underscored_pluralized_name}"
+  end
+end

--- a/lib/generators/operation/templates/controller.erb
+++ b/lib/generators/operation/templates/controller.erb
@@ -1,0 +1,39 @@
+class <%= @controller_name %> < ApplicationController
+  def index; end
+
+  def show
+    op Operations::<%= @class_name %>::Load
+  end
+
+  def new
+    op Operations::<%= @class_name %>::Create
+  end
+
+  def create
+    if run Operations::<%= @class_name %>::Create
+      # handle successful case
+    else
+      # handle error case
+    end
+  end
+
+  def edit
+    op Operations::<%= @class_name %>::Update
+  end
+
+  def update
+    if run Operations::<%= @class_name %>::Update
+      # handle successful case
+    else
+      # handle error case
+    end
+  end
+
+  def destroy
+    if run Operations::<%= @class_name %>::Destroy
+      # handle successful case
+    else
+      # handle error case
+    end
+  end
+end

--- a/lib/generators/operation/templates/create.erb
+++ b/lib/generators/operation/templates/create.erb
@@ -1,0 +1,11 @@
+module Operations::<%= @class_name %>
+  class Create < RailsOps::Operation::Model::Create
+    schema3 do
+      hsh? :<%= @underscored_name %> do
+
+      end
+    end
+
+    model ::<%= @class_name %>
+  end
+end

--- a/lib/generators/operation/templates/destroy.erb
+++ b/lib/generators/operation/templates/destroy.erb
@@ -1,0 +1,9 @@
+module Operations::<%= @class_name %>
+  class Destroy < RailsOps::Operation::Model::Destroy
+    schema3 do
+      str! :id
+    end
+
+    model ::<%= @class_name %>
+  end
+end

--- a/lib/generators/operation/templates/load.erb
+++ b/lib/generators/operation/templates/load.erb
@@ -1,0 +1,5 @@
+module Operations::<%= @class_name %>
+  class Load < RailsOps::Operation::Model::Load
+    model ::<%= @class_name %>
+  end
+end

--- a/lib/generators/operation/templates/update.erb
+++ b/lib/generators/operation/templates/update.erb
@@ -1,0 +1,12 @@
+module Operations::<%= @class_name %>
+  class Update < RailsOps::Operation::Model::Update
+    schema3 do
+      str! :id
+      hsh? :<%= @underscored_name %> do
+
+      end
+    end
+
+    model ::<%= @class_name %>
+  end
+end

--- a/test/unit/rails_ops/generators/operation_generator_test.rb
+++ b/test/unit/rails_ops/generators/operation_generator_test.rb
@@ -1,0 +1,170 @@
+require 'test_helper'
+require 'generators/operation/operation_generator'
+
+class OperationGeneratorTest < Rails::Generators::TestCase
+  tests OperationGenerator
+  destination File.expand_path('../../../tmp', File.dirname(__FILE__))
+
+  setup do
+    prepare_destination
+
+    # Add an empty routes file
+    Dir.mkdir(File.join(destination_root, 'config'))
+    File.open(File.join(destination_root, 'config', 'routes.rb'), 'w') do |f|
+      f.write <<~ROUTES
+        Rails.application.routes.draw do
+        end
+      ROUTES
+    end
+  end
+
+  def test_all
+    run_generator ['User']
+
+    # Check that operations are generated
+    assert_operations
+
+    # Check that views are generated
+    assert_views
+
+    # Check that the controller is generated
+    assert_controller
+
+    # Check that the routes entry is added
+    assert_routes
+  end
+
+  def test_no_views
+    run_generator ['User', '--skip-views']
+
+    assert_operations
+    assert_controller
+    assert_routes
+
+    # Check that the views were skipped
+    %w(index show new edit).each do |view|
+      assert_no_file "app/views/users/#{view}.html.haml"
+    end
+  end
+
+  def test_no_controller
+    run_generator ['User', '--skip-controller']
+
+    assert_operations
+    assert_views
+    assert_routes
+
+    # Check that the controller was skipped
+    assert_no_file 'app/controllers/users_controller.rb'
+  end
+
+  def test_no_routes
+    run_generator ['User', '--skip-routes']
+
+    assert_operations
+    assert_views
+    assert_controller
+
+    # Check that the routes were not added
+    assert_file 'config/routes.rb' do |routes|
+      assert_no_match(/resources :users/, routes)
+    end
+  end
+
+  def test_skip_all
+    run_generator ['User', '--skip-controller', '--skip-routes', '--skip-views']
+
+    assert_operations
+
+    # Check that the controller was skipped
+    assert_no_file 'app/controllers/users_controller.rb'
+
+    # Check that the routes were not added
+    assert_file 'config/routes.rb' do |routes|
+      assert_no_match(/resources :users/, routes)
+    end
+
+    # Check that the views were skipped
+    %w(index show new edit).each do |view|
+      assert_no_file "app/views/users/#{view}.html.haml"
+    end
+  end
+
+  def test_only_operations
+    run_generator ['User', '--only-operations']
+
+    assert_operations
+
+    # Check that the controller was skipped
+    assert_no_file 'app/controllers/users_controller.rb'
+
+    # Check that the routes were not added
+    assert_file 'config/routes.rb' do |routes|
+      assert_no_match(/resources :users/, routes)
+    end
+
+    # Check that the views were skipped
+    %w(index show new edit).each do |view|
+      assert_no_file "app/views/users/#{view}.html.haml"
+    end
+  end
+
+  def test_lowercase_name
+    run_generator ['user']
+
+    # Check that operations are generated
+    assert_operations
+
+    # Check that views are generated
+    assert_views
+
+    # Check that the controller is generated
+    assert_controller
+
+    # Check that the routes entry is added
+    assert_routes
+  end
+
+  private
+
+  def assert_operations
+    assert_file 'app/operations/user/create.rb' do |operation|
+      assert_match(/module Operations::User/, operation)
+      assert_match(/class Create < RailsOps::Operation::Model::Create/, operation)
+      assert_match(/model ::User/, operation)
+    end
+    assert_file 'app/operations/user/destroy.rb' do |operation|
+      assert_match(/module Operations::User/, operation)
+      assert_match(/class Destroy < RailsOps::Operation::Model::Destroy/, operation)
+      assert_match(/model ::User/, operation)
+    end
+    assert_file 'app/operations/user/load.rb' do |operation|
+      assert_match(/module Operations::User/, operation)
+      assert_match(/class Load < RailsOps::Operation::Model::Load/, operation)
+      assert_match(/model ::User/, operation)
+    end
+    assert_file 'app/operations/user/update.rb' do |operation|
+      assert_match(/module Operations::User/, operation)
+      assert_match(/class Update < RailsOps::Operation::Model::Update/, operation)
+      assert_match(/model ::User/, operation)
+    end
+  end
+
+  def assert_views
+    %w(index show new edit).each do |view|
+      assert_file "app/views/users/#{view}.html.haml"
+    end
+  end
+
+  def assert_controller
+    assert_file 'app/controllers/users_controller.rb' do |controller|
+      assert_match(/class UsersController < ApplicationController/, controller)
+    end
+  end
+
+  def assert_routes
+    assert_file 'config/routes.rb' do |routes|
+      assert_match(/resources :users/, routes)
+    end
+  end
+end


### PR DESCRIPTION
Closes #11 

Added a basic generator for Operations, which can generate a skeleton for CRUD operations, a controller, empty view files and a routing entry.

As the frontend logic depends heavily on the application (and the version of Rails in use, e.g. Turbo vs. Turbolinks applications), the view files are empty and the controller only provides an empty `if/else` construct for the `create`, `update` and `destroy` actions.

This still should speed up development, as the basic boilerplate code is now automatically generated.

@remofritzsche Is it okay for you if I merge this? I think we can progressively enhance the generator as we use it, but as a basic version this should work well.