### PR TITLE
Double nesting and validations

### DIFF
--- a/lib/rails_ops/operation.rb
+++ b/lib/rails_ops/operation.rb
@@ -75,7 +75,7 @@ class RailsOps::Operation
   # Returns an array of exception classes that are considered as validation
   # errors.
   def validation_errors
-    [RailsOps::Exceptions::ValidationFailed, ActiveRecord::RecordInvalid]
+    [RailsOps::Exceptions::ValidationFailed, ActiveRecord::RecordInvalid, RailsOps::Exceptions::SubOpValidationFailed]
   end
 
   # Returns a copy of the operation's params, wrapped in an OpenStruct object.


### PR DESCRIPTION
If multiple levels of nesting are used, validation errors are not caught if they are thrown in the `perform_nested_model_ops!1 function in `lib/rails_ops/mixins/model/nesting.rb` on the `model.validate!` line. This Problem can possibly also happen on other parts of the code.
